### PR TITLE
2-Munbin-Lee

### DIFF
--- a/Munbin-Lee/README.md
+++ b/Munbin-Lee/README.md
@@ -2,5 +2,6 @@
 
 | 차시 |    날짜    | 문제유형 | 링크 |
 |:----:|:---------:|:----:|:-----:|
-| 1차시 | 2022.10.07 |  BFS  | - |
+| 1차시 | 2022.10.09 |  BFS  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/132266">부대복귀</a> |
+| 2차시 | 2022.10.10 |  구현  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/152995">인사고과</a> |
 ---

--- a/Munbin-Lee/README.md
+++ b/Munbin-Lee/README.md
@@ -3,5 +3,5 @@
 | 차시 |    날짜    | 문제유형 | 링크 |
 |:----:|:---------:|:----:|:-----:|
 | 1차시 | 2022.10.09 |  BFS  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/132266">부대복귀</a> |
-| 2차시 | 2022.10.10 |  구현  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/152995">인사고과</a> |
+| 2차시 | 2022.10.11 |  구현  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/152995">인사고과</a> |
 ---

--- a/Munbin-Lee/구현/2-인사고과.cpp
+++ b/Munbin-Lee/구현/2-인사고과.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+bool incentive(int x, const vector<vector<int>>& scores) {
+    for (int i = 0; i < x; i++) {
+        if (scores[x][0] < scores[i][0]
+           && scores[x][1] < scores[i][1]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int solution(vector<vector<int>> scores) {
+    pair<int, int> wanho = {scores[0][0], scores[0][1]};
+    
+    // 인센티브를 받지 못하는 경우
+    
+    for (auto& score : scores) {
+        if (score[0] > wanho.first && score[1] > wanho.second) {
+            return -1;
+        }
+    }
+    
+    // 점수 합 기준으로 내림차순 정렬
+    
+    sort(scores.begin(), scores.end(), [&wanho] (const auto &a, const auto &b) {
+        if (a[0] + a[1] == b[0] + b[1]) {
+            return a[0] != b[0] && a[0] == wanho.first;
+        }
+        return a[0] + a[1] > b[0] + b[1];
+    });
+    
+    // 석차 판별
+    
+    int rank = 1;
+
+    for (int i = 0; i < scores.size(); i++) {
+        if (!incentive(i, scores)) continue;
+        if (scores[i][0] == wanho.first
+           && scores[i][1] == wanho.second) {
+            return rank;
+        }
+        rank++;
+    }
+    
+    return -1;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/152995

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
3시간

## ✨ 수도 코드
문제 자체는 어렵지 않다고 생각했지만 에러와 오답이 나와서 당황했던 문제.
<br>

A의 두 점수가 모두 B의 그것보다 높은 경우, 'A가 B의 **상위호환**', 'B가 A의 **하위호환**'이라 하겠다.
<br>

앞으로 pseudo code 서식은 C와 파이썬 섞어서 쓰겠습니다...
파이썬으로 변환하는 거 은근 귀찮네요...

```python
wanho = scores[0]
for (score in scores) {
    if (score[0] > wanho[0] && score[1] > wanho[1]) {
        return -1
    }
}
```

완호의 점수를 따로 저장하고,

```scores```를 순회하면서, 완호의 상위호환이 존재한다면 -1을 반환한다.
<br>

```python
sort(scores, [] (a, b) {
    if (sum(a) == sum(b) && a[0] == wanho[0]) return true
    return sum(a) > sum(b)
})
```

```scores```를 점수의 합 기준으로 내림차순 정렬한다.

점수의 합이 같다면 완호의 점수가 먼저 나오게 정렬한다.
<br>

```python
rank = 1
for (score in scores) {
    if (score[0] == wanho[0] && score[1] == wanho[1]) {
        return rank
    }
    rank++;
}
```

```scores```를 순회하면서, ```rank```를 1씩 늘리고 완호가 나오면 return한다.

완호의 동점자 중에서는 완호가 제일 앞에 있기 때문에, 동점자 규칙은 무시하면 된다.
<br>

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/2b947733-d556-4bda-87cf-4eec2aaf2054)
호기롭게 코드를 제출했으나 결과는 오답이었다.

오답인 건 그렇다치고, segmentation fault가 어떻게 나올 수 있는지 의문이었다.
<br>

구글링을 해보니, C++의 ```compare```은 무조건 **strict weak ordering**을 준수해야했다.

strict weak ordering은 대소관계를 규정할 때 모순을 방지하기 위한 규칙이다.

이 중 한가지 규칙은 **compare(a, b)가 true이면 compare(b, a)는 false여야한다**는 규칙이다.

내가 만든 compare 람다 함수의 경우 a와 b 모두 완호의 값과 같다면

compare(a, b), compare(b, a) 모두 true이기 때문에 모순이 발생한 것이다.
<br>

```python
sort(scores, [] (a, b) {
    if (sum(a) == sum(b)) {
        return a[0] != b[0] && a[0] == wanho[0]
    }
    return sum(a) > sum(b)
})
```

규칙을 지키면서, (a != b인 경우에) 동치가 나오게 코드를 수정했다.
<br>

또 생각해봤더니, 이전 풀이에서는 오류가 있었다.

1등과 완호 사이에 **누군가의 하위호환**이 있을 수도 있기 때문이다.

이 하위호환을 어떻게 처리해야할 지 고민했다.

단순 비교만으로 처리하려면 ```O(N^2)```의 시간 복잡도를 가진다.
<br>

```python
bool incentive(x, scores) {
    for (i = 0; i < x; i++) {
        if (scores[x][0] < scores[i][0]
           && scores[x][1] < scores[i][1]) {
            return false
        }
    }
    return true
}

...

rank = 1
for (i = 0; i < len(scores); i++) {
    if (not incentive(i, scores)) continue
    if (scores[i][0] == wanho[0]
       && scores[i][1] == wanho[1]) {
        return rank
    }
    rank++
}
```

근데 단순 비교만 해도 최대 1072ms로 통과하였다.

백준이었으면 무조건 시간 초과 났을텐데...

프로그래머스는 문제를 만들고 왜 저격 케이스를 넣지 않는지 모르겠다.

완호의 합을 최소로 한 후에, 인센티브를 받지 못하는 사람이 한 명도 없으면,

```1/2 * 100000 ^ 2``` 번 처리해야해서 무조건 시간 초과가 일어난다.

반대로 생각하면, 프로그래머스는 같은 시간 복잡도 내에서도 최적화가 가능한 껀덕지가 있다는 점을 장점으로 봐야겠다.
<br>

더 적은 시간 복잡도를 가지는 코드를 작성하고 싶었지만, 도저히 내 머리로는 떠오르지 않았다.

그래서 구글링해서 ```O(N)```(정렬 제외) 풀이를 발견했다. (출처 : https://sundryy.tistory.com/109)

```python
def solution(scores):
    wanho = scores[0]
    rank = 1
    maxSecondScore = 0
    
    for score in sorted(scores, key = lambda x : (-x[0], x[1])):
        if wanho[0] < score[0] and wanho[1] < score[1]:
            return -1
        if score[1] < maxSecondScore :
            continue
        maxSecondScore = score[1]
        if sum(wanho) < sum(score):
            rank += 1
    
    return rank
```
```scores```를 정렬할 때, **첫 번째 원소는 내림차순으로, 두 번째 원소는 오름차순으로 정렬한다.**

```scores```를 순회하면서 완호가 인센티브를 받을 수 없는 경우 -1을 반환한다.

```maxSecondScore```는 두 번째 원소의 최댓값을 저장하는 변수이다.

두 번째 원소가 이제까지 나온 두 번째 원소의 최댓값보다 작으면 인센티브를 못 받으니, continue한다.

처음에는 어? 단순히 두 번째 원소가 작다고해서 하위호환이라는 보장이 있나?? 생각했는데

첫 번째 원소를 기준으로 내림차순, 두 번째 원소를 기준으로 오름차순 정렬되어 있기 때문에

두 번째 원소가 작다면 첫 번째 원소가 다르다. 즉, 첫 번째 원소가 작다.

따라서 두 번째 원소가 작으면 하위호환이다.

와... 짧은 코드 안에 이런 발상을 어떻게 집어넣었나 싶다.

**완호의 상위호환인 사람 수 + 1**이 그대로 ```rank```가 된다. 이 부분도 지린다.

이렇게 하면 동점자의 경우를 생각하지 않아도 된다.

여러모로 배울 게 많았던 코드.

## 📚 새롭게 알게된 내용

strict weak ordering
https://stackoverflow.com/questions/1541817/sort-function-c-segmentation-fault