### PR TITLE
17-Munbin-Lee

### DIFF
--- a/Munbin-Lee/README.md
+++ b/Munbin-Lee/README.md
@@ -15,4 +15,5 @@
 | 12차시 | 2023.11.01 |  투포인터  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/67258">보석 쇼핑</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/38 |
 | 13차시 | 2023.11.04 |  구현  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/87391">공 이동 시뮬레이션</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/44 |
 | 14차시 | 2023.11.06 |  DP  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/131129">카운트 다운</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/49 |
+| 16차시 | 2023.11.12 |  정수론  | <a href="https://www.acmicpc.net/problem/11689">GCD(n, k) = 1</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/57 |
 ---

--- a/Munbin-Lee/정수론/17-GCD(n, k) = 1.py
+++ b/Munbin-Lee/정수론/17-GCD(n, k) = 1.py
@@ -1,6 +1,3 @@
-from itertools import combinations
-from math import prod
-
 tempN = n = int(open(0).read())
 div = 2
 factors = []
@@ -18,8 +15,23 @@ if tempN > 1:
 
 answer = n
 
-for i in range(1, len(factors) + 1):
-    for comb in combinations(factors, i):
-        answer -= n // prod(comb) * (i % 2 and 1 or -1)
+
+def dfs(cur, curBit):
+    global answer
+    if cur == len(factors):
+        if curBit == 0: return
+        prod = 1
+        for idx, factor in enumerate(factors):
+            if curBit & (1 << idx):
+                prod *= factor
+        hasEvenBit = bin(curBit).count('1') % 2 == 0
+        answer += n // prod * (hasEvenBit and 1 or -1)
+        return
+
+    dfs(cur + 1, curBit)
+    dfs(cur + 1, curBit | (1 << cur))
+
+
+dfs(0, 0)
 
 print(answer)

--- a/Munbin-Lee/정수론/17-GCD(n, k) = 1.py
+++ b/Munbin-Lee/정수론/17-GCD(n, k) = 1.py
@@ -1,0 +1,25 @@
+from itertools import combinations
+from math import prod
+
+tempN = n = int(open(0).read())
+div = 2
+factors = []
+
+while div * div <= tempN:
+    if tempN % div == 0:
+        factors.append(div)
+        tempN //= div
+        while tempN % div == 0:
+            tempN //= div
+    div += 1
+
+if tempN > 1:
+    factors.append(tempN)
+
+answer = n
+
+for i in range(1, len(factors) + 1):
+    for comb in combinations(factors, i):
+        answer -= n // prod(comb) * (i % 2 and 1 or -1)
+
+print(answer)


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/11689

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간

```diff
- text in red
+ text in green
! text in orange
# text in gray
@@ text in purple (and bold)@@
```

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
프로그래밍 경진 대회 문제 중 3번을 거의 손도 못 댔다.

(3번 문제는 https://www.geeksforgeeks.org/largest-subsequence-gcd-greater-1/ 참고)

그래서 백준에서 GCD를 검색해서 비슷한 문제를 찾던 중 이 문제를 발견했다.

---

문제를 처음 보고 생각한 것 : ```n```이 무려 $10^{12}$, **1조**이다. **$O(N)$ 풀이조차도 불가능하다.**

먼저 예시를 보고 규칙을 찾으려 했다.
<br>

5 : 1, 2, 3, 4 = 4개

10 : 1, 3, 7, 9 = 4개
<br>

제외된 숫자를 살펴보면,

5 : 5

10 : 2, 4, 5, 6, 8, 10

뭔가 규칙이 보였다.

5에서 제외된 숫자는 5 하나이고, 10에서 제외된 숫자는 2 또는 5의 배수였다.

즉, 소인수분해와 관련이 있을거라 생각했다. 소인수분해는 $O(\log{N})$ 으로 처리가 가능하기 때문에 충분히 가능하다!!
<br>

조금 더 확실히 하기 위해 45에서 제외된 숫자를 예로 들어보자.

45 : 3, 5, 6, 9, 10, 12, 15, 18, 20, 21, 24, 25, 27, 30, 33, 35, 36, 39, 40, 42, 45

모두 3의 배수와 5의 배수이다. 즉, 소인수분해와 관련이 있다는 추측의 가능성이 높아진다.

45에서 3의 배수의 개수 = 45 / 3 = 15

45에서 5의 배수의 개수 = 45 / 5 = 9

그런데, 15의 배수면 공통으로 빠지기 때문에 다시 더해줘야한다.
<br>

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/afab21fc-0ec7-4847-8b34-3a5332f697e1)

중학생 때 배웠던 합집합의 공식과 같다. $A + B - A∩B$ 를 구해주면 된다.

만약 소인수가 A, B, C 3개라면 $A + B + C - A∩B - A∩C - B∩C + A∩B∩C$ 를 구하면 된다.

이제 코드로 구현해보자.

---

```python
tempN = n = int(open(0).read())
div = 2
factors = []

while div * div <= tempN:
    if tempN % div == 0:
        factors.append(div)
        tempN //= div
        while tempN % div == 0:
            tempN //= div
    div += 1

# 수동으로 마지막 소인수 저장
if tempN > 1:
    factors.append(tempN)
```

먼저 정수를 입력받은 후, ```n```과 ```tempN```에 저장한다.

```div```는 나누는 수이고, ```factors```는 소인수를 저장할 리스트이다.

연산은 $\sqrt{tempN}$ 까지만 실행한다.

만약 ```tempN``` 전체에 대하여 실행한다면 1조 번 실행되므로 시간초과가 발생할 것이다.

만약 ```tempN```이 ```div```로 나누어 떨어진다면, 즉, 소인수라면 ```factors```에 저장한다. 그 후 ```div```를 1씩 증가시킨다.

연산을  $\sqrt{tempN}$ 까지만 실행하므로, 가끔씩 마지막 소인수를 저장하지 못할 때가 있다.

(ex. ```n = 14```라면 ```div```가 3일때까지만 실행하지만, 7도 소인수이다.)

그 부분은 수동으로 저장하여 준다.

---

```python
answer = n

for i in range(1, len(factors) + 1):
    for comb in combinations(factors, i):
        answer -= n // prod(comb) * (i % 2 and 1 or -1)
```

그리고, 합집합을 구하는 과정에서는 ```itertools``` 라이브러리의 ```combinations``` 함수를 사용했다.

1부터 ```len(factors)```까지의 조합을 모두 구하여 더하거나 빼준다.

예를 들어, ```n```을 ```A, B, C``` 3개의 소인수로 소인수 분해하였다고 해보자.

```python
answer -= n // A
answer -= n // B
answer -= n // C
answer += n // (A * B)
answer += n // (A * C)
answer += n // (B * C)
answer -= n // (A * B * C)
```

이렇게 작동할 것이다.

---

그런데, 이렇게 끝나면 파이썬에 너무나도 유리한 문제가 아닐까?

그래서 생각을 해보았다.

$factorsC1$ + $factorsC2$ + $factorsC3$ + ... + $factorsCfactors$ 를 하는 것은 사실상

각 ```factor```에 대하여 고를지 안 고를지 선택하는 것과 같았다.

즉, $2^{factors}$이다. 그럼 ```factors```의 최댓값은 무엇일까?

$2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 = 200560490130$ (2005억)

여기에 다음 소수인 37을 곱하면 1조를 넘어간다.

즉, 소인수의 최대 갯수는 11개이다.

2^11이면 2048로 굉장히 적은 수이므로, 비트마스킹을 쓰든 배열을 쓰든 충분히 적은 시간과 메모리로 처리가 가능하다.

나는 비트마스킹을 좋아하기 때문에 비트마스킹으로 처리해보았다.

---

```python
answer = n

def dfs(cur, curBit):
    global answer
    if cur == len(factors):
        if curBit == 0: return
        prod = 1
        for idx, factor in enumerate(factors):
            if curBit & (1 << idx):
                prod *= factor
        hasEvenBits = bin(curBit).count('1') % 2 == 0
        answer += n // prod * (hasEvenBits and 1 or -1)
        return

    dfs(cur + 1, curBit)
    dfs(cur + 1, curBit | (1 << cur))

dfs(0, 0)
```
<br>

---

문제를 풀 때는 몰랐는데, **오일러 파이 함수**라는 놈을 사용하면 쉽게 풀 수 있다.

코드를 보니 내 코드랑 비슷한 것 같기도 하고, 아니 같기도 하고... 어쨌든 실전 코테라면 내 방법으로 푸는 게 맞겠지 뭐.

https://degurii.tistory.com/189


## 📚 전체 코드
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

```python
tempN = n = int(open(0).read())
div = 2
factors = []

while div * div <= tempN:
    if tempN % div == 0:
        factors.append(div)
        tempN //= div
        while tempN % div == 0:
            tempN //= div
    div += 1

if tempN > 1:
    factors.append(tempN)

answer = n

def dfs(cur, curBit):
    global answer
    if cur == len(factors):
        if curBit == 0: return
        prod = 1
        for idx, factor in enumerate(factors):
            if curBit & (1 << idx):
                prod *= factor
        hasEvenBits = bin(curBit).count('1') % 2 == 0
        answer += n // prod * (hasEvenBits and 1 or -1)
        return

    dfs(cur + 1, curBit)
    dfs(cur + 1, curBit | (1 << cur))

dfs(0, 0)

print(answer)
```