### PR TITLE
20-Munbin-Lee

### DIFF
--- a/Munbin-Lee/README.md
+++ b/Munbin-Lee/README.md
@@ -19,5 +19,6 @@
 | 16차시 | 2023.11.10 |  위상정렬  | <a href="https://www.acmicpc.net/problem/2056">작업</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/56 |
 | 17차시 | 2023.11.12 |  정수론  | <a href="https://www.acmicpc.net/problem/11689">GCD(n, k) = 1</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/57 |
 | 18차시 | 2023.11.17 |  투포인터  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/12904">가장 긴 팰린드롬</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/61 |
-| 18차시 | 2023.11.20 |  투포인터  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/178870">연속된 부분 수열의 합</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/69 |
+| 19차시 | 2023.11.20 |  투포인터  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/178870">연속된 부분 수열의 합</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/69 |
+| 20차시 | 2023.11.23 |  유니온파인드  | <a href="https://leetcode.com/problems/redundant-connection-ii">Redundant Connection II</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/75 |
 ---

--- a/Munbin-Lee/유니온파인드/Redundant Connection II.cpp
+++ b/Munbin-Lee/유니온파인드/Redundant Connection II.cpp
@@ -1,0 +1,50 @@
+class Solution {
+public:
+    vector<int> parents, roots;
+
+    int find(int x) {
+        if (x == roots[x]) return x;
+
+        return roots[x] = find(roots[x]);
+    }
+
+    vector<int> findRedundantDirectedConnection(vector<vector<int>>& edges) {
+        int n = edges.size();
+        parents.resize(n + 1, -1);
+        roots.resize(n + 1);
+        iota(roots.begin(), roots.end(), 0);
+
+        int hasDoubleParents = -1;
+        array<int, 2> doubleParents;
+        vector<int> cycle;
+
+        for (auto &edge : edges) {
+            int u = edge[0];
+            int v = edge[1];
+
+            // parent가 2개인 경우
+            if (parents[v] != -1){
+                hasDoubleParents = v;
+                doubleParents = {parents[v], u};
+                parents[v] = -1;
+                continue;
+            }
+
+            parents[v] = u;
+
+            // 사이클인 경우
+            if (find(u) == find(v)) {
+                cycle = {u, v};
+                continue;
+            }
+            
+            roots[v] = u;
+        }
+
+        if (hasDoubleParents == -1) return cycle;
+
+        if (cycle.empty()) return {doubleParents[1], hasDoubleParents};
+
+        return {doubleParents[0], hasDoubleParents};
+    }
+};


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://leetcode.com/problems/redundant-connection-ii

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
5시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

문제를 해결하려면 먼저 **rooted tree**에 대해 이해할 필요가 있다.

방향 그래프에서 ```A``` -> ```B```일 때 ```A```를 ```B```의 ```parent```라 하자.

```root node```는 ```parent```를 가지지 않고, 그 외의 노드는 모두 ```parent```를 하나만 가져야한다.

그리고 가장 중요한 조건은 ```n```개의 ```edges```가 입력으로 들어온다는 것이다.

노드가 ```n```개인 트리에서 모든 트리를 연결하기 위해서는 $n-1$ 개의 ```edge```가 필요하다.

즉, 이 문제에서 제거해야할 ```edge```는 단 하나이다.

단, 제거할 수 있는 ```edge```가 하나밖에 존재한다는 뜻은 아니다.

제거할 수 있는 ```edge```가 여러 개라면 가장 마지막으로 입력된 ```edge```를 제거해야 한다.

---

문제를 풀려고 삽질하다보면 이 문제는 3가지의 케이스로 분류할 수 있다는 사실을 알 수 있다.

여기에 도달하기까지 해쉬맵, DFS, 유니온 파인드 등 많은 시행착오를 거쳤다.

<br>

- **A** : 하나의 ```node```가 2개의 ```parent```를 가지는 경우

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/76065930-f3f9-44c5-b879-5efaf71a2f23)

노드 3은 ```노드 1, 노드 2``` 2개의 ```parent```를 가지고 있다.

이 경우에는 해당 노드의 ```parent```를 이루는 ```edge``` 2개 중 늦게 입력된 하나를 제거하면 된다.

<br>

- **B** : 사이클을 가지는 경우

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/4a362710-8294-440a-93f1-32d0ec08e1d2)

```노드 1, 노드 2, 노드 3, 노드 4```의 사이클이 존재한다.

이 경우에는 사이클을 이루는 ```edges``` 중 가장 마지막으로 입력된 ```edge```를,

즉 사이클을 완성하는 ```edge```를 제거하면 된다.

<br>

- A와 B를 **동시에** 만족하는 경우

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/fb02f6a3-dfe7-4af1-82fb-5315ecfc2bf3)

노드 1이 ```노드 2, 노드 3``` 2개의 ```parent```를 가지면서, ```노드 1, 노드 4, 노드 2```의 사이클이 존재한다.

이 경우에는 2개의 ```parent```를 가지는 노드에서 ```parent```를 연결하는 두 개의 ```edge``` 중 사이클을 이루는 ```edge```를 제거하면 된다.

---

2개의 ```parent```를 가지고 있는지 검사하는 방법은 굉장히 단순하다.

```edges```를 순회하면서 ```parents```에 ```parent```를 저장하는데, 이미 저장된 값이 있다면 2개를 가지고 있는 것이다.

```cpp
int hasDoubleParents = -1;
array<int, 2> doubleParents;

for (auto &edge : edges) {
    int u = edge[0];
    int v = edge[1];

    // parent가 2개인 경우
    if (parents[v] != -1){
        hasDoubleParents = v;
        doubleParents = {parents[v], u};
        parents[v] = -1;
        continue;
    }

    parents[v] = u;
    // ...
}
```

---

사이클을 확인하는 가장 확실한 방법은 모든 노드를 DFS 등을 사용하여 완전탐색하는 것이다.

$O(n)$ 밖에 걸리지 않아 효율적인 방법이지만, 이후의 처리가 굉장히 귀찮아진다.

2개의 ```parent```를 가지고 있는 과정을 수행한 후에 따로 1부터 순회하기 때문에,

어떤 노드가 사이클에 포함되는지 파악하기가 어렵다. (가능은 하다.)

그래서 유니온 파인드를 사용하였다.

유니온 파인드가 무엇인지 궁금하다면 [여기](https://www.google.com/search?q=유니온+파인드) 클릭.

---

```cpp
int find(int x) {
    if (x == roots[x]) return x;

    return roots[x] = find(roots[x]);
}
```

전형적인 유니온 파인드의 ```find``` 함수이다. 따로 설명할 것은 없다.

---

```cpp
// 파이썬의 roots = list(range(0, n + 1)) 과 동일
iota(roots.begin(), roots.end(), 0);

// 사이클인 경우
if (find(u) == find(v)) {
    cycle = {u, v};
    continue;
}

// union
roots[v] = u;
```

사이클은 두 노드의 ```roots```가 같은 지 판단하여 알아낼 수 있다.

```union``` 로직이 좀 특이한데, 보통은 크기를 비교하여 swap하는데,

문제의 그래프는 유방향 그래프이기 때문에 순서에 일관되게 고정해줘야 한다.

---

```cpp
if (hasDoubleParents == -1) return cycle;
```

2개의 ```parent```를 가진 노드가 없다면 **B**의 경우이기 때문에, 사이클을 완성하는 ```edge```를 반환한다.

---

```cpp
if (cycle.empty()) return {doubleParents[1], hasDoubleParents};
```

만약 사이클이 없다면 **A**의 경우이기 때문에, 2개의 ```parent``` 중 늦게 입력된 ```parent```(```doubleParents[1]```)가 포함된 ```edge```를 반환한다.

---

```cpp
return {doubleParents[0], hasDoubleParents};
```

A와 B가 동시에 있는 경우라면 2개의 ```parent``` 중 먼저 입력된 ```parent```(```doubleParents[0]```)가 포함된 ```edge```를 반환한다.

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
사진 출처
https://zxi.mytechroad.com/blog/wp-content/uploads/2017/10/685-ep83.png