### PR TITLE
27-tgyuuAn

### DIFF
--- a/tgyuuAn/BFS/탈옥.py
+++ b/tgyuuAn/BFS/탈옥.py
@@ -1,0 +1,98 @@
+from collections import deque
+from copy import deepcopy
+
+total_test_case = int(input())
+
+for _ in range(total_test_case):
+    height, width = map(int,input().split())
+
+    _map = []
+    start_point = []
+
+    dx = [0,0,-1,1]
+    dy = [-1,1,0,0]
+
+    #감옥 밖을 자유롭게 돌아다닐 수 있도록, 감옥 주변을 `.`` 으로 감싼다.
+    _map.append(["." for _ in range(width+2)])
+
+    for h in range(height):
+        width_input = list("."+input()+".")
+        _map.append(width_input)
+
+        for w,w_input in enumerate(width_input):
+            if w_input == "$":
+                _map[h+1][w] = "."
+                start_point.append((h+1,w))
+
+    _map.append(["." for _ in range(width+2)])
+
+    # 중간 체크
+    # for h in range(height+2):
+    #    print(_map[h])
+
+    
+    def bfs(start_h, start_w):
+        deq = deque([(start_h, start_w)])
+        open_door_table = [[-1 for _ in range(width+2)] for _ in range(height+2)]
+        open_door_table[start_h][start_w] = 0
+
+        while deq:
+            now_h, now_w = deq.popleft()
+            # print(now_h,now_w)
+
+            for dir in range(4):
+                new_h, new_w = now_h + dy[dir], now_w + dx[dir]
+
+                if new_h < 0 or new_h > height +1:
+                    continue
+
+                if new_w < 0 or new_w > width +1:
+                    continue
+
+                if _map[new_h][new_w] == "*":
+                    continue
+
+                if open_door_table[new_h][new_w] != -1:
+                    continue
+
+                if _map[new_h][new_w] == ".":
+                   deq.appendleft([new_h,new_w])
+                   open_door_table[new_h][new_w] = open_door_table[now_h][now_w]
+
+                elif _map[new_h][new_w] == "#":
+                   deq.append([new_h,new_w])
+                   open_door_table[new_h][new_w] = open_door_table[now_h][now_w] + 1
+
+        return open_door_table
+
+    open_door_table1 = bfs(start_point[0][0],start_point[0][1])
+    open_door_table2 = bfs(start_point[1][0],start_point[1][1])
+    open_door_table3 = bfs(0,0)
+
+    # for h in range(height+2):
+    #     print(open_door_table1[h])
+    # print()
+
+    # for h in range(height+2):
+    #     print(open_door_table2[h])
+    # print()
+ 
+    # for h in range(height+2):
+    #     print(open_door_table3[h])
+
+    answer = int(1e9)
+    for h in range(height):
+         for w, (val1, val2, val3) in enumerate(zip(open_door_table1[h], open_door_table2[h], open_door_table3[h])):
+             if val1 == -1 or val2 == -1 or val3 == -1:
+                 continue
+ 
+             if _map[h][w] == "*":
+                 continue
+             
+             elif _map[h][w] == ".":
+                 answer = min(answer, val1 + val2 + val3)
+ 
+             elif _map[h][w] == "#":
+                 answer = min(answer, val1 + val2 + val3 - 2)
+
+    print(answer)

--- a/tgyuuAn/README.md
+++ b/tgyuuAn/README.md
@@ -26,4 +26,5 @@
 | 22차시 | 2023.11.23 |  다익스트라  | <a href="https://www.acmicpc.net/problem/1238">파티</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/78
 | 23차시 | 2023.12.01 |  다익스트라  | <a href="https://www.acmicpc.net/problem/1504">특정한 최단 경로</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/84
 | 24차시 | 2023.12.23 |  다익스트라  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/49189">가장 먼 노드</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/86
+| 27차시 | 2024.01.01 |  BFS  | <a href="https://www.acmicpc.net/problem/9376">탈옥</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/96
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[탈옥](https://www.acmicpc.net/problem/9376)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
4시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

간만에 어려운 문제를 풀었는데,

**인사이트 제대로 넓혔다.** _(인사이트를 넓혔다는 말은 온전히 내 힘으로 풀지 못했다는 뜻과도 동치다..)_

<br><br><br><br>

일단 이 문제를 풀기 위해서 **0-1 BFS** 라는 기술을 알아야했다.

이 기술을 모르면 풀지 못한다.

<br><br><br><br><br><br>

### 0-1 BFS ⭐
<hr>

기존 다익스트라는 다익스트라를 돌릴 때 간선에 양수인 코스트를 부여했을 때 최단 거리를 구하는 알고리즘이다.

하지만, 0-1 BFS는 간선의 코스트가 0 혹은 1일 때의 최단 거리를 구해주게 되는 알고리즘이다.

<br><br><br><br><br><br>

**"어, 그러면 일반 BFS랑 뭐가 다른데요?"**

그림으로 설명해주겠다.

<br><br><br><br><br><br>

아래와 같은 그림이 있을 때,

**1번 노드**에서 **2번 노드**로 가고싶다고 가정하자.

<br>

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/116813010/6fc40db6-307b-499f-a589-00cf3cf85fcd)

<br>

**기존 BFS**를 돌리게 되면, 1번 노드에서 인접한 노드 2번과 3번을 모두 탐색할텐데,

목적지인 **2번 노드**를 탐색할 때 해당 **BFS가 종료**된다.

이 때 **방문 횟수**는 1이고, **코스트**는 `1`이 든다.

> 1 -> 2

<br><br><br>

반면, **0-1 BFS**를 돌리게 되면, 1번 노드에서 인접한 노드 2번과 3번을 탐색할 때,

0 코스트인 간선을 먼저 타고 들어가서 BFS를 종료시킨다.

이 때의 **방문 횟수**는 3이고,  **코스트**는 `0`이 든다.

> 1 -> 3-> 4-> 2

<br><br><br><br><br><br>

**"그럼 구현은 어떻게 하는데요?"**

<br><br><br><br><br><br>

매우 쉽다.

**기존 BFS**는 그냥 무지성으로 인접한 노드를 발견했을 때, `append`를 해줘서 **큐의 맨 뒤로 삽입**했지만,

**0-1 BFS**는 **코스트가 0인 간선**을 만나서 노드를 만났을 때는 `appendleft`를 해서 **큐의 앞 단에 삽입**하고,

**코스트가 1인 간선**을 만나면 기존 BFS처럼 append를 해줘서 **큐의 맨 뒤로 삽입**해서 탐색 시간을 늦춘다.

<br><br><br><br><br><br>

일단 **0-1 BFS**에 대한 간단한 설명은 이게 끝이다.

더 자세히 알고싶다면, [해당 링크](https://chan9.tistory.com/120)로 들어가서 보면 좋겠다!

<br><br><br><br><br><br>

이 알고리즘은 이 문제를 풀면서 처음 접했는데,

위 **0-1 BFS**를 이용해서 **서브넷 네트워크**도 찾을 수 있을 것 같다는 생각이 들었다.

실제로는 어떻게 구현되어 있는 지는 모르겠지만..

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/116813010/38c3ef74-dae1-4516-bb0b-3da5e8e0df9b)

<br><br><br><br><br><br>


### 다시 문제로 돌아와서 ⭐

<hr><br><br>

문제에서 생각해주어야 할 부분이 있다.

> 상근이는 감옥 밖을 자유롭게 이동할 수 있고, 평면도에 표시된 죄수의 수는 항상 두 명이다.

바로 이 부분인데,

나는 처음에 접근할 때, 가장자리에 있는 ```"."``` 이나 ```"#"``` 을 따로 

```entrance_dedications```라는 List에 저장시켜놓고, 각 출입 후보에서 모두 BFS를 돌리려고 생각했다.

<br><br><br><br><br><br>

하지만 이 부분에서도 다른 레퍼런스를 참고하니 잡기술을 적용시켜주니 구현 난이도가 확 내려갔는데,

`감옥 밖을 자유롭게 이동할 수 있다` 는 말은 결국 **감옥 밖을 지나갈 수 있는 빈 공간으로 덮어주면 훨씬 구현 난이도가 쉬워진다.**

그렇기 때문에 이 부분에서 

```python
for _ in range(total_test_case):
    height, width = map(int,input().split())
    _map = []

    _map.append(["." for _ in range(width+2)])     # 0번 row를 "." 으로 감쌈

    for h in range(height):
        width_input = list("."+input()+".")               # 0번 column과 마지막 column을 "."으로 감쌈
        _map.append(width_input)

        for w,w_input in enumerate(width_input):
            if w_input == "$":
                _map[h+1][w] = "."
                start_point.append((h+1,w))

    _map.append(["." for _ in range(width+2)])      # 마지막 row를 "." 으로 감쌈
```

와 같이 ```"."```으로 감싸주었다.

<br><br><br><br><br><br>

자 이제 밖에서 부터 죄수 2명을 구출하러 가보자.

이 때 고려해야 할 중요한 사항은, **한 번 열린 문은 계속해서 열려있다**는 점이다.

이렇게 **문이 계속해서 열려있다** 는 점을 고려하지 않을 경우,

**밖에서 죄수 1을 구하러 갈 때 열었던 문**을, **죄수 2를 구하러 갈 때 한 번 더 열게 될 수도 있다.**

<br><br><br><br><br><br>

**그럼 똑같은 문을 어떻게 하면 다시 안 열 수 있을까?**

**열었던 문을 버퍼에 저장 해놓을까?**

_그건 매우 비효율적으로 보인다._

<br><br><br><br><br><br>

**똑같은 문을 안 열고 최소한의 문을 여는 방법**은,

**바깥에서 출발,** 

**죄수 1에서부터 출발,** 

**죄수 2에서 부터 출발**해서 **세 명이 만나는 접점을 구하는 것**이다.

이게 실제로 죄수1, 죄수2가 움직이는 것이 아닌, **상근이가 혼자 움직이지만 최소한의 거리를 구하기 위해서 죄수로부터 출발했다고 생각하자.**

말이 어려운데 여하튼 다 상근이가 움직이는 게 맞다.

그냥 똑같은 문을 안 열기 위한 일종의 잡기술이다.

<br><br><br><br><br><br>

정리해보자면, 

**바깥에서 u까지, 죄수 1부터 u까지, 죄수 2부터 u까지**의 **최소 문 여는 횟수를 구하는 것**이 **최적의 해**이다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/116813010/4012d967-655e-4853-a17c-b68db7ba91c4)

그러면 **우리가 해야할 일**은 이 **접점** `u`를 **어디로 설정 하느냐**를 정해주면 끝이다.

<br><br><br><br><br><br>

**OK** 거의 다 왔다.

우리는 이제 **0-1 BFS** 와 상근이의 시작 위치인 **감옥 바깥을 "."으로 감싸는 작업**,

마지막으로 **똑같은 문을 열지 않기 위해서 `상근`, `죄수 1`, `죄수 2`가 각각 움직여서 하나의 접점에서 만나는 전략**까지 알아냈다.

<br><br><br><br><br><br>

그러면 이제 **상근이 기준**에서 BFS를 돌려서 각각의 지도에서 문을 여는 횟수,
_(이 때, 상근이의 기준점은 감옥 바깥에서 어디든지 시작해도 되므로 0,0에서 시작하였다.)_

**죄수 1의 기준**에서 BFS를 돌려서 각각의 지도에서 문을 여는 횟수,

**죄수 2의 기준**에서 BFS를 돌려서 각각의 지도에서 문을 여는 횟수를 구한다.

<br><br><br><br><br><br>


예를 들면 문제에 나와있는 첫 번째 예시를 기준으로 하면,

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/116813010/e23ba217-75c9-4e40-a462-ab84a9da49b8)

가장 위에가 **죄수 1기준** 문을 여는 횟수 테이블,

두 번째가 **죄수 2 기준** 문을 여는 횟수 테이블,

세 번째가 **상근이**가 문을 여는 횟수 테이블이다.

<br><br><br><br><br><br>

이렇게 **세 개의 문 여는 횟수 테이블**을 구했다면,

마지막으로 **모든 행/열을 순회하면서 문 여는 횟수가 가장 적은 부분 접점 u로 설정**하고,

**해당 접점에서 문 여는 횟수를 반환**해주면 끝이다.

<br><br><br>

이 때, 중요한 것이 있는데, 만약 **만나는 접점 u를 문이 있는 위치로 설정**했을 경우,

**한 명만 열어도 될 문을 세 명이 다 열게 되므로 `-2`를 해준다.**

```python

    answer = int(1e9)
    for h in range(height):
         for w, (val1, val2, val3) in enumerate(zip(open_door_table1[h], open_door_table2[h], open_door_table3[h])):
             if val1 == -1 or val2 == -1 or val3 == -1:
                 continue
 
             if _map[h][w] == "*":
                 continue
             
             elif _map[h][w] == ".":
                 answer = min(answer, val1 + val2 + val3)
 
             elif _map[h][w] == "#":
                 answer = min(answer, val1 + val2 + val3 - 2)
```

이렇게 하면 진짜 끝이다.

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

**- 0-1 BFS에 대한 내용을 알게되었다.**

위에서 자세히 설명했으므로 아래에선 스킵한다.

<br><br><br>

**- 바깥에서 자유롭게 돌아다닐 수 있을 때, 한 줄을 더 감싸주는 잡기술을 배웠다.**

위에서 자세히 설명했으므로 아래에선 스킵한다.

<br><br><br>

**- 길이 한 개가 아닌, 도착지점이 여러개일 때, 중복되는 행위를 하지 않게 하기 위해서 접점을 이용하는 풀이를 배웠다.**

위에서 자세히 설명했으므로 아래에선 스킵한다.

<br><br><br><br><br><br><br><br><br>

**솔직히 이 문제 진짜 어렵다.**

이 문제 풀면서 배운 것이 한 두 개가 아니다.

아니 0-1 BFS는 그렇다 치고, 

**세 개의 스타팅 포인트에서 접점으로 답을 구하는 생각**은 도대체 어떤 사람의 아이디어에서 나온 것인지 진짜 궁금하다.