### PR TITLE
25-yuna83

### DIFF
--- a/yuna83/README.md
+++ b/yuna83/README.md
@@ -23,4 +23,8 @@
 | 19차시 | 2023.12.29 |  다익스트라  | [지름길](https://www.acmicpc.net/problem/1446)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/94|
 | 20차시 | 2024.01.04 |  다익스트라  | [특정한 최단 경로](https://www.acmicpc.net/problem/1504)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/100|
 | 21차시 | 2024.01.13 |  구현  | [신규 아이디 추천](https://school.programmers.co.kr/learn/courses/30/lessons/72410)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/107|
+| 22차시 | 2024.01.16 |  DFS/BFS  | [양궁 대회](https://school.programmers.co.kr/learn/courses/30/lessons/92342?language=python3)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/111|
+| 23차시 | 2024.01.19 |  DFS/BFS  | [마법의 엘리베이터](https://school.programmers.co.kr/learn/courses/30/lessons/148653)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/113|
+| 24차시 | 2024.01.22 |  스택/큐  | [뒤에 있는 큰 수 찾기](https://school.programmers.co.kr/learn/courses/30/lessons/154539)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/117|
+| 25차시 | 2024.01.25 |  스택/큐  | [주식 가격](https://school.programmers.co.kr/learn/courses/30/lessons/42584)|https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/121|
 ---

--- a/yuna83/스택/큐/주식 가격.py
+++ b/yuna83/스택/큐/주식 가격.py
@@ -1,0 +1,13 @@
+def solution(prices):
+    length = len(prices)
+   
+    answer = [i for i in range(length - 1, -1, -1)] #마지막에서 처음까지 역순으로 반복
+   
+    stack = [0]
+    for i in range(1, length):
+        while stack and prices[stack[-1]] > prices[i]:
+            j = stack.pop()
+            answer[j] = i - j #주식이 떨어진 기간을 계산하여 저장
+        stack.append(i) #주식 가격이 떨어지지 않은 상태에서 가장 최근에 나타난 주식 가격의 인덱스
+ 
+    return answer


### PR DESCRIPTION
## 🔗 문제 링크
[주식 가격](https://school.programmers.co.kr/learn/courses/30/lessons/42584)

<br>


## ✔️ 소요된 시간
30분

<br>


## ✨ 수도 코드

```prices```: 초 단위로 기록된 주식 가격 배열
가격이 떨어지지 않는 기간이 몇 초인지 **return**

주어진 주식 가격이 **얼마 동안 유지되는지**를 계산하면 된다!

<br>

ex)```prices```=[1, 2, 3, 2, 3]일 때
	
1초일 때 1원은 쭉 떨어지지 않는다 > 4초
2초일 때 2원은 쭉 떨어지지 않는다 > 3초
3초일 때 3원은 4초에서 가격이 떨어진다 > 1초
4초일 때 2원은 쭉 떨어지지 않는다 > 1초
5초일 때 3원은 쭉 떨어지지 않는다 > 0초

```return```=[4, 3, 1, 1, 0]

반복문을 이용하여 값을 비교하다가 자신보다 낮은 값을 만났을 시 
걸린 시간(초)를 계산하여 ```answer```를 갱신해준다!

<br>

```prices```를 담는 자료구조에 따라 **코드**, **복잡도**가 어떻게 달라지는지
확인하면서 풀었습니다!!

<br>


### 큐
: 선입선출, 줄을 서서 기다리는 것처럼 가장 뒤에 있는 자료가 가장 최근에 들어온 자료
라이브러리없이 리스트로 구현 가능하지만 시간복잡도가 **O(n)** 으로
```from collections import deque``` 사용 시 양쪽 연산이 자유로워져 시간복잡도 **O(1)** 으로
라이브러리를 활용하는 게 효율적이다!


```python
from collections import deque

def solution(prices):
    answer = []  
    prices_q = deque(prices)  
   
    while prices_q:
        price = prices_q.popleft()  
        time = 0
       
        for q in prices_q:
            time += 1  
            if price > q:
                break  
               
        answer.append(time)
   
    return answer 
```

큐에서 하나의 주식 가격을 꺼내고 ```price = prices_q.popleft()```
그 가격보다 낮은 가격이 나올 때까지 시간을 증가 ```for q in prices_q: time += 1```  
해당 시간을 리스트로 만들어 반환


<br>


### 스택
: 후입선출, 가장 위에 있는 자료가 가장 최근에 들어온 자료
***append***: 삽입하는 연산
***pop***: 삭제하는 연산
파이썬에서 별도의 라이브러리없이 구현 가능!

```python
def solution(prices):
    length = len(prices)
   
    answer = [i for i in range(length - 1, -1, -1)] #마지막에서 처음까지 역순으로 반복
   
    stack = [0]
    for i in range(1, length):
        while stack and prices[stack[-1]] > prices[i]:
            j = stack.pop()
            answer[j] = i - j #주식이 떨어진 기간을 계산하여 저장
        stack.append(i) #주식 가격이 떨어지지 않은 상태에서 가장 최근에 나타난 주식 가격의 인덱스
 
    return answer
```

스택은 후입선출으로 가장 최근에 들어온 자료가 가장 위(**[-1]**)에 있다!
```prices[stack[-1]] > prices[i]```이 조건이 성립하지 않을 시 그냥 넘어간다

<br>

큐를 이용했을 시의 결과
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/140380279/4ba72ac1-607f-4475-a995-de58c2d840a8)

<br>

스택을 이용했을 시의 결과
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/140380279/15b08e73-0b29-4e70-914f-92c936bba2cd)


<br>

큐를 이용할 땐 while문에서 n번 반복, 내부 for문에서 n번 반복으로 **O(n^2)**,
스택을 이용할 땐 for문에서 n번 반복, 내부 while문의 연산은 기본적인 연산들로 
n번 반복이 필수시간이 아니므로(=O(1)) **O(n)** 이므로 
**스택을 활용할 때** 시간이 더 절약된다!!

<br>

## 📚 새롭게 알게된 내용
어떤 자료구조를 사용하는지에 따라 복잡도가 달라지는 걸
체감할 수 있는 문제였습니다!!
준성님 문제 추천 감사합니다😀

도움받은 출처
https://deftkang.tistory.com/175

스택/큐 설명
https://devuna.tistory.com/22

<br>