### PR TITLE
32-pknujsp

### DIFF
--- a/pknujsp/BFS/32-숨바꼭질 3.py
+++ b/pknujsp/BFS/32-숨바꼭질 3.py
@@ -1,0 +1,31 @@
+from sys import *
+from collections import *
+
+n, k = map(int, stdin.readline().strip().split())
+
+max_idx = 100001
+
+q = deque([(n, 0)])
+visited = [False] * max_idx
+visited[n] = True
+
+while q:
+    x, cost = q.popleft()
+    if x == k:
+        print(cost)
+        break
+
+    nx = x + x
+    if nx < max_idx and not visited[nx]:
+        visited[nx] = True
+        q.appendleft((nx, cost))
+
+    nx = x - 1
+    if 0 <= nx and not visited[nx]:
+        visited[nx] = True
+        q.append((nx, cost + 1))
+
+    nx = x + 1
+    if nx < max_idx and not visited[nx]:
+        visited[nx] = True
+        q.append((nx, cost + 1))

--- a/pknujsp/README.md
+++ b/pknujsp/README.md
@@ -32,4 +32,5 @@
 | 28차시 | 2024.01.16 |     그리디      |       [무지의 먹방 라이브](https://school.programmers.co.kr/learn/courses/30/lessons/42891)       | [#110](https://github.com/lgoLeadMe/AlgoLeadMe-1/pull/110) |
 | 29차시 | 2024.01.18 | DFS, UNION-FIND |                       [순열 사이클](https://www.acmicpc.net/problem/10451)                        | [#112](https://github.com/lgoLeadMe/AlgoLeadMe-1/pull/112) |
 | 30차시 | 2024.01.23 |       DP        |                           [ABBC](https://www.acmicpc.net/problem/25381)                           | [#119](https://github.com/lgoLeadMe/AlgoLeadMe-1/pull/119) |
-| 31차시 | 2024.01.30 |       SORT        |                          [멀티버스 Ⅱ](https://www.acmicpc.net/problem/18869)                           | [#123](https://github.com/lgoLeadMe/AlgoLeadMe-1/pull/123) |
+| 31차시 | 2024.01.30 |      SORT       |                        [멀티버스 Ⅱ](https://www.acmicpc.net/problem/18869)                        | [#123](https://github.com/lgoLeadMe/AlgoLeadMe-1/pull/123) |
+| 32차시 | 2024.02.04 |       BFS       |                        [숨바꼭질 3](https://www.acmicpc.net/problem/13549)                        | [#127](https://github.com/lgoLeadMe/AlgoLeadMe-1/pull/127) |


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[숨바꼭질 3](https://www.acmicpc.net/problem/13549)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
45분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

## n에서 k로 가는 가장 빠른 시간을 구하는 문제

BFS로 풀 수 있는 문제입니다

큐를 만들고 **좌우로 이동하는 경우**와 **2배 만큼 이동하는 경우** 모두를 고려하면서 큐가 빌 때 까지 BFS를 진행합니다

### 1. deque과 중복 처리를 방지하기 위한 방문 visited 리스트 생성

### 2.  n을 시작점으로 하여 BFS를 진행

탐색 시 이동하는 데 걸린 시간을 계산해야 하므로 큐의 원소를 `좌표, 이동 시간` 형식으로 맞춥니다

- 큐가 빌 때까지 반복
- 큐에 원소를 추가할 때는 방문 처리
- 문제 조건이 **n과 k는 0 이상 100,000이하** 이기 때문에 모든 가능성을 고려하여 100,000까지 이동해봅니다

1. 큐 `popleft()` : 좌표, 이동 시간
2. 좌표가 k와 같다면 이동시간을 출력하고 탐색을 종료
3. 다르다면, 우선 **2배 만큼** 순간 이동
   - 순간 이동이므로 이동 시간에 변화없음
   - **2배 이동하여 도착한 위치**가 `100_000` 이하이고, 아직 방문하지 않았다면 큐의 **맨 앞**에 추가
   - 맨 앞에 추가하는 이유는 최소 시간을 찾는게 목적이므로 최우선으로 확인해봐야 하기 때문입니다
   - 만약 뒤에 추가한다면 최소 시간을 찾기 까지 불필요한 탐색을 더 진행하게 될 수도 있습니다
4. 왼쪽과 오른쪽으로 한 칸씩 이동하는 경우도 고려
   - 이동 시간을 1 증가
   - 마찬가지로 결과 위치가 아직 방문하지 않은 경우에만 큐에 추가
   - 왼쪽으로 이동 :  위치가 `0` 이상일 때 큐 맨 뒤에 추가
   - 오른쪽으로 이동 :  위치가 `100_000` 이하일 때 큐 맨 뒤에 추가


### n : 5, k = 17


단계 | 현재 위치 | 동작 | 결과 위치 | 추가 | 설명
-- | -- | -- | -- | -- | --
1 | 5 | 초기 상태 |   | (5, 0) | 시작 위치와 이동 시간 0을 큐에 추가하여 시작
2 | 5 | x - 1 | 4 | (4, 1) | 위치 4로 이동, 시간1 추가
  | 5 | x * 2 | 10 | (10, 0) | 위치 10으로 순간 이동, 시간추가 없음
  | 5 | x + 1 | 6 | (6, 1) | 위치 6으로 이동, 시간1 추가
3 | 10 | x - 1 | 9 | (9, 1) | 위치 9로 이동, 시간1 추가
  | 10 | x * 2 | 20 | (20, 0) | 위치 20으로 순간 이동, 시간추가 없음
  | 10 | x + 1 | 11 | (11, 1) | 위치 11로 이동, 시간1 추가
4 | 20 | x - 1 | 19 | (19, 1) | 위치 19로 이동, 시간1 추가
  | 20 | x * 2 | 40 | (40, 0) | 위치 40으로 순간 이동, 시간 추가 없음
  | 20 | x + 1 | 21 | (21, 1) | 위치 21로 이동, 시간 1 추가

위와 같은 방식으로 탐색을 하다가 현 위치가 k와 같아지면 탐색을 종료합니다

```python
n, k = map(int, stdin.readline().strip().split())
max_idx = 100001

q = deque([(n, 0)])
visited = [False] * max_idx
visited[n] = True

while q:
    x, cost = q.popleft()
    if x == k:
        print(cost)
        break

    nx = x + x
    if nx < max_idx and not visited[nx]:
        visited[nx] = True
        q.appendleft((nx, cost))

    nx = x - 1
    if 0 <= nx and not visited[nx]:
        visited[nx] = True
        q.append((nx, cost + 1))

    nx = x + 1
    if nx < max_idx and not visited[nx]:
        visited[nx] = True
        q.append((nx, cost + 1))
```

## 참고할 만한 다른 사람의 풀이

다른 방식으로 [풀어낸 코드](https://www.acmicpc.net/source/54621310)가 있어 가져와봤습니다
제 풀이와 달리 BFS가 아닌 재귀식이고, n 대신에 k를 n으로 이동시키는 방식입니다

```python
def f(n, k):
    if n >= k:
        return n - k
    elif k == 1:
        return 1
    elif k % 2 == 0:
        return min(k - n, f(n, k // 2))
    else:
        return 1 + min(f(n, k + 1), f(n, k - 1))

n, k = map(int, stdin.readline().strip().split())
print(f(n, k))
```


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
