### PR TITLE
34-Munbin-Lee

### DIFF
--- a/Munbin-Lee/README.md
+++ b/Munbin-Lee/README.md
@@ -31,4 +31,5 @@
 | 28차시 | 2024.01.16 |  그래프  | <a href="https://school.programmers.co.kr/learn/courses/30/lessons/258711">도넛과 막대 그래프</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/109 |
 | 29차시 | 2024.01.19 |  유니온파인드  | <a href="https://www.acmicpc.net/problem/1043">거짓말</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/114 |
 | 30차시 | 2024.01.23 |  정수론  | <a href="https://www.acmicpc.net/problem/17425">약수의 합</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/118 |
+| 34차시 | 2024.02.06 |  구현  | <a href="https://www.acmicpc.net/problem/1756">피자 굽기</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/133 |
 ---

--- a/Munbin-Lee/구현/34-피자 굽기.cpp
+++ b/Munbin-Lee/구현/34-피자 굽기.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <stack>
+
+using namespace std;
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    int D, N;
+    cin >> D >> N;
+
+    stack<int> minOvens;
+    int mn = 1087654321;
+
+    while (D--) {
+        int oven;
+        cin >> oven;
+
+        mn = min(mn, oven);
+        minOvens.emplace(mn);
+    }
+
+    while (N--) {
+        int pizza;
+        cin >> pizza;
+
+        while (!minOvens.empty() && minOvens.top() < pizza) {
+            minOvens.pop();
+        }
+
+        if (!minOvens.empty()) {
+            minOvens.pop();
+        } else {
+            cout << '0';
+            return 0;
+        }
+    }
+
+    cout << minOvens.size() + 1;
+
+    return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->

https://www.acmicpc.net/problem/1756

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->

1시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

**문제**

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/9c9e2c4d-4a27-4140-9788-6e4b0e588de9)

위 사진은 [5, 6, 4, 3, 6, 2, 3] 오븐에 [3, 2, 5] 순서대로 피자를 넣은 모습이다.

오븐에 피자를 떨어트리면 오븐의 지름이 피자의 지름보다 작은 칸의 위 칸에 피자가 걸려서 고정된다.

마지막 피자의 위치를 구하자.

---

브루트포스로 구현하면 $O(DN)$ = 30만 * 30만으로 시간 초과가 발생할 것이다.

그래서 어떻게 풀지 고민하다가 누적합의 아이디어를 떠올렸다.

각 오븐의 최솟값을 누적해서 기록하는 것이다.

누적 최솟값이라고 표현하는 게 맞겠다.

[5, 6, 4, 3, 6, 2, 3] 오븐이라면,  [5, 5, 4, 3, 3, 2, 2]

이렇게 표현한 이유는 위 칸보다 아래 칸이 넓어도 쓸모가 없기 때문이다.

---

위 예제에서 [3, 2, 5] 순서대로 피자를 넣으면

[5, 5, 4, 3, 3v, 2, 2]

[5, 5, 4, 3v, 3v, 2, 2]

[5, 5v, 4, 3v, 3v, 2, 2]

v위치에 피자가 들어간다.

이는 오븐의 지름이 피자의 지름 이상인 최후의 지점이다.

누적 최솟값은 정렬된 값이므로, 이분탐색을 사용할 수 있겠다고 생각했다.

---

```cpp
// [0, hi]에서 value 이상인 최후의 인덱스를 반환
auto binarySearch = [&](int hi, int value) {
    int lo = 0;
    int answer = -1;

    while (lo <= hi) {
        int md = (lo + hi) / 2;

        if (minOvens[md] >= value) {
            answer = md;
            lo = md + 1;
        } else {
            hi = md - 1;
        }
    }

    return answer;
};
```

주석에 쓰여진 내용을 그대로 구현한 코드다.

이를 토대로 제출하였더니 정답이 떴다.

---

그런데, 굳이 이분탐색을 사용해야할까?

어차피 피자의 위치 인덱스는 뒤에서부터 앞으로 다가온다.

그렇다면 스택을 사용하면 되지 않을까?

---

```cpp
stack<int> minOvens;
int mn = 1087654321;

while (D--) {
    int oven;
    cin >> oven;

    mn = min(mn, oven);
    minOvens.emplace(mn);
}
```

스택에 누적 최솟값을 넣는다.

---

```cpp
while (N--) {
    int pizza;
    cin >> pizza;

    // 피자를 넣을 공간이 부족한 부분들은 pop한다.
    while (!minOvens.empty() && minOvens.top() < pizza) {
        minOvens.pop();
    }

    // 피자를 넣는 위치이므로, 한 번 더 pop한다.
    if (!minOvens.empty()) {
        minOvens.pop();
    } else {
        // 피자를 넣을 수 없다면 0을 출력한다.
        cout << '0';
        return 0;
    }
}

// 남은 스택의 크기 + 1을 반환한다.
cout << minOvens.size() + 1;
```

---

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/e6910348-9256-4517-ba9d-53dfb538d55d)
위가 스택, 아래가 이분탐색

이론상 이분탐색의 $O(N\log{N})$에 비해, $O(N)$으로 빠르지만, 그렇게 차이가 나지는 않는다.

## 📚 전체 코드
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

```cpp
#include <iostream>
#include <stack>

using namespace std;

int main() {
    ios_base::sync_with_stdio(false);
    cin.tie(nullptr);

    int D, N;
    cin >> D >> N;

    stack<int> minOvens;
    int mn = 1087654321;

    while (D--) {
        int oven;
        cin >> oven;

        mn = min(mn, oven);
        minOvens.emplace(mn);
    }

    while (N--) {
        int pizza;
        cin >> pizza;

        while (!minOvens.empty() && minOvens.top() < pizza) {
            minOvens.pop();
        }

        if (!minOvens.empty()) {
            minOvens.pop();
        } else {
            cout << '0';
            return 0;
        }
    }

    cout << minOvens.size() + 1;

    return 0;
}
```