### PR TITLE
35-Munbin-Lee

### DIFF
--- a/Munbin-Lee/README.md
+++ b/Munbin-Lee/README.md
@@ -35,4 +35,5 @@
 | 32차시 | 2024.01.30 |  백트래킹  | <a href="https://www.acmicpc.net/problem/17114">하이퍼 토마토</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/124 |
 | 33차시 | 2024.02.04 |  정수론  | <a href="https://www.acmicpc.net/problem/14905">소수 4개의 합</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/128 |
 | 34차시 | 2024.02.06 |  구현  | <a href="https://www.acmicpc.net/problem/1756">피자 굽기</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/133 |
+| 35차시 | 2024.02.18 |  백트래킹  | <a href="https://www.acmicpc.net/problem/24891">단어 마방진</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/140 |
 ---

--- a/Munbin-Lee/백트래킹/35-단어 마방진.py
+++ b/Munbin-Lee/백트래킹/35-단어 마방진.py
@@ -1,0 +1,22 @@
+from itertools import permutations
+
+stdin = open(0)
+
+L, N = map(int, stdin.readline().split())
+words = sorted(stdin.read().splitlines())
+
+# 단어 순열 x가 단어 마방진인지 확인하는 함수
+def isValid(x):
+    for i in range(L):
+        for j in range(L):
+            if x[i][j] != x[j][i]: return False
+    
+    return True
+
+for perm in permutations(words, L):
+    if not isValid(perm): continue
+    
+    print(*perm, sep='\n')
+    exit()
+
+print('NONE')


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/24891

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
2시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

먼저 브루트포스 풀이를 생각해보자.

모든 경우의 단어 순열을 구하려면 $_N\mathrm{P}_L$ 의 시간이 필요하다.

각 단어 순열에 대하여, 단어 마방진인지 확인하려면 $L^2$ 의 시간이 필요하다.

따라서, 브루트포스 알고리즘의 시간 복잡도는 $O(_N\mathrm{P}_L L^2)$ = 20 * 19 * 18 * 17 * 16 * 5 * 5 = 46512000 이므로 시간 내에 통과할 수 있다.

파이썬의 `itertools.permutaions`로 날먹해보자.

```py
from itertools import permutations

stdin = open(0)

L, N = map(int, stdin.readline().split())
words = stdin.read().splitlines()

# 단어 순열 x가 단어 마방진인지 확인하는 함수
def isValid(x):
    for i in range(L):
        for j in range(L):
            if x[i][j] != x[j][i]: return False
    
    return True

answer = ('a',)

for perm in permutations(words, L):
    if not isValid(perm): continue
    
    answer = min(answer, perm)

if len(answer) == 1:
    print('NONE')
    exit()

print(*answer, sep='\n')
```

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/887434bc-b665-4742-85bb-a2149bda31e4)

무지성 브루트포스로도 충분히 통과할 수 있다.

---

사실 난 처음에는 백트래킹으로 먼저 풀려고 했다.

단어들을 사전 순으로 정렬하고, BFS로 제일 먼저 탐색에 성공한 단어 마방진이 답일 것이라고 생각했다.

하지만 틀렸다.

그래서 BFS로 그냥 모든 단어 마방진을 백트래킹 탐색하였다.

```cpp
#include <iostream>
#include <vector>
#include <tuple>
#include <queue>

using namespace std;

int main() {
    ios_base::sync_with_stdio(false);
    cin.tie(nullptr);

    int L, N;
    cin >> L >> N;

    vector<string> words(N);

    for (auto &word: words) {
        cin >> word;
    }

    queue<tuple<int, int, vector<vector<char>>>> q;
    vector<vector<char>> init(L, vector<char>(L));
    q.emplace(0, 0, init);

    vector<vector<char>> answer = {{'Z' + 1}};

    while (!q.empty()) {
        auto [index, mask, cur] = q.front();
        q.pop();

        auto isValid = [&](int i) {
            for (int j = 0; j < L; j++) {
                if (!cur[index][j]) continue;
                if (cur[index][j] != words[i][j]) return false;
            }

            return true;
        };

        for (int i = 0; i < N; i++) {
            if (mask & (1 << i)) continue;
            if (!isValid(i)) continue;

            auto next = cur;

            for (int j = 0; j < L; j++) {
                next[index][j] = words[i][j];
                next[j][index] = words[i][j];
            }

            if (index + 1 == L) {
                answer = min(answer, next);
                continue;
            }

            q.emplace(index + 1, mask | (1 << i), next);
        }
    }

    if (answer.size() == 1) {
        cout << "NONE";
        return 0;
    }

    for (auto &word: answer) {
        for (char ch: word) {
            cout << ch;
        }
        cout << '\n';
    }

    return 0;
}
```

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/fc14b18a-1b51-448a-a253-25aa3b189927)

C++인 것을 감안했을 때, 브루트포스(pypy3)와 백트래킹(C++)의 시간 차이가 얼마 나지 않는다.

---

그럼 어떻게 효율적으로 풀 수 있을까?

단어를 정렬하고, bfs 대신 dfs를 돌려서 처음에 나오는 단어 마방진을 출력하였더니 맞았다.

```py
stdin = open(0)

L, N = map(int, stdin.readline().split())
words = sorted(stdin.read().splitlines())

def isValid(x):
    for i in range(L):
        for j in range(L):
            if x[i][j] != x[j][i]: return False
    
    return True

def dfs(index, mask, cur):
    if index == L:
        if not isValid(cur): return
        
        print(*cur, sep='\n')
        exit()
    
    for i in range(N):
        if mask & (1 << i): continue
        dfs(index + 1, mask | (1 << i), cur + [words[i]])

dfs(0, 0, [])

print('NONE')
```

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/1a165916-2c51-4fbb-b48b-4cdd4d3e0443)

시간이 절반 가량으로 줄어들었다.

index가 마지막일 때만 체크하지 말고, 중간 중간에 단어마방진인지 체크하여 브루트포스->백트래킹으로 바꾸면 훨씬 더 빨라질 것이다.

<br>

왜 BFS가 아니라 DFS를 돌려야할까?

모르겠다.

---

그런데, `itertools.permutations`의 탐색 순서를 생각해보니 dfs의 탐색 순서와 같다.

그럼 그냥 dfs를 구현하지 말고 첫번째 perm을 출력하면 되는 것 아닌가?

```py
from itertools import permutations

stdin = open(0)

L, N = map(int, stdin.readline().split())
words = sorted(stdin.read().splitlines())

# 단어 순열 x가 단어 마방진인지 확인하는 함수
def isValid(x):
    for i in range(L):
        for j in range(L):
            if x[i][j] != x[j][i]: return False
    
    return True

for perm in permutations(words, L):
    if not isValid(perm): continue
    
    print(*perm, sep='\n')
    exit()

print('NONE')
```

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/100560031/cb9ad461-81eb-4b7a-8b5e-6dee1f806f8e)

permutations 특성 상 최적화가 되어있어서 세 번째 풀이보다는 살짝 빠르다.