### PR TITLE
27-SeongHoonC

### DIFF
--- a/SeongHoonC/README.md
+++ b/SeongHoonC/README.md
@@ -28,4 +28,5 @@
 | 24차시 | 2024.05.18| 백트래킹 | <a href="https://www.acmicpc.net/problem/9663">n-queen</a> |https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/192 |
 | 25차시 | 2024.05.22| 브루트포스 | <a href="https://www.acmicpc.net/problem/14500">테트로미노</a> |https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/194 |
 | 26차시 | 2024.05.26| 그래프 | <a href="https://www.acmicpc.net/problem/1389">케빈 베이컨의 6단계 법칙</a> |https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/200 |
+| 27차시 | 2024.05.30| ??? | <a href="https://www.acmicpc.net/problem/16724">피리 부는 사나이</a> |https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/201 |
 ---

--- a/SeongHoonC/graph/graph.kt
+++ b/SeongHoonC/graph/graph.kt
@@ -1,0 +1,56 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+private lateinit var graph: Array<Array<String>>
+private lateinit var visited: Array<Array<Boolean>>
+private lateinit var br: BufferedReader
+
+val dx = listOf(1, 0, 0, -1)
+val dy = listOf(0, 1, -1, 0)
+val dD = listOf("D", "R", "L", "U")
+val dDInverse = listOf("U", "L", "R", "D")
+fun main() {
+    br = BufferedReader(InputStreamReader(System.`in`))
+    val (n, m) = br.readLine().split(" ").map { it.toInt() }
+
+    graph = Array(n) { Array(m) { "X" } }
+    visited = Array(n) { Array(m) { false } }
+
+    repeat(n) {
+        val line = br.readLine().chunked(1)
+        line.forEachIndexed { index: Int, s: String ->
+            graph[it][index] = s
+        }
+    }
+    var count = 0
+    for (x in 0 until n) {
+        for (y in 0 until m) {
+            if (findSafeZone(x, y, n, m)) count++
+        }
+    }
+    println(count)
+}
+
+// bfs 로 같은 사이클에 존재하는 애들 다 찾기
+private fun findSafeZone(x: Int, y: Int, n: Int, m: Int): Boolean {
+    if (visited[x][y]) return false
+    val q = ArrayDeque<Pair<Int, Int>>()
+    q.add(x to y)
+    while (q.isNotEmpty()) {
+        val now = q.removeFirst()
+        val nowDirection = dD.indexOf(graph[now.first][now.second])
+        for (i in 0..3) {
+            val nextX = now.first + dx[i]
+            val nextY = now.second + dy[i]
+            // 범위 넘어감
+            if (nextX >= n || nextY >= m || nextX < 0 || nextY < 0) continue
+            if (visited[nextX][nextY]) continue
+            // 이동 방향과 같을 때 or 현재 구역으로 이동할 곳
+            if (dDInverse[i] == graph[nextX][nextY] || i == nowDirection) {
+                visited[nextX][nextY] = true
+                q.add(nextX to nextY)
+            }
+        }
+    }
+    return true
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[피리 부는 사나이](https://www.acmicpc.net/problem/16724)

## 오늘의 한 컷
피리 부는 성우를 위해 한 컷
![군대이미지](https://wimg.mk.co.kr/meet/neds/2013/05/image_readtop_2013_416881_1369806571932233.jpg)

## ✔️ 소요된 시간
40분

## ✨ 수도 코드
방향끼리 연결된 개수를 정하면 되는 문제라고 생각했습니다.

처음엔 dfs 로 풀려고 했었는데요.

현재 구역으로 오는 방향을 알 수 있으면 bfs 로 해도 풀리지 않을까? 라는 생각을 했습니다.

예를 들어 이런 모양이라면
<img width="303" alt="image" src="https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/108349655/5e842698-d4b1-47df-a65a-04788e1d8936">

현위치로 가리키는 구역과 다음 구역을 큐에 추가하는 식입니다.
<img width="317" alt="image" src="https://github.com/AlgoLeadMe/AlgoLeadMe-1/assets/108349655/5fcb1bf0-f89a-4a8a-ab43-2bede62bc740">

그래서 방향과 해당 방향, 그리고 반대 방향을 저장해놓고

```kotlin
val dx = listOf(1, 0, 0, -1)
val dy = listOf(0, 1, -1, 0)
val dD = listOf("D", "R", "L", "U")
val dDInverse = listOf("U", "L", "R", "D")
```

조건문으로 해당되는 구역을 큐에 추가하도록 했습니다.

```kotlin
// bfs 로 같은 사이클에 존재하는 애들 다 찾기
private fun findSafeZone(x: Int, y: Int, n: Int, m: Int): Boolean {
    if (visited[x][y]) return false
    val q = ArrayDeque<Pair<Int, Int>>()
    q.add(x to y)
    while (q.isNotEmpty()) {
        val now = q.removeFirst()
        val nowDirection = dD.indexOf(graph[now.first][now.second])
        for (i in 0..3) {
            val nextX = now.first + dx[i]
            val nextY = now.second + dy[i]

            // 범위 넘어감
            if (nextX >= n || nextY >= m || nextX < 0 || nextY < 0) continue

            // 이미 방문함
            if (visited[nextX][nextY]) continue

            // 현재 구역의 다음 방향 or 현재 구역으로 이동할 구역이면
            if (dDInverse[i] == graph[nextX][nextY] || i == nowDirection) {
                visited[nextX][nextY] = true
                q.add(nextX to nextY)
            }
        }
    }
    return true
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
