### PR TITLE
71-tgyuuAn

### DIFF
--- a/tgyuuAn/README.md
+++ b/tgyuuAn/README.md
@@ -77,4 +77,5 @@
 | 68차시 | 2024.08.06 |  그리디  | <a href="https://www.acmicpc.net/problem/24337">가희와 탑</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/226
 | 69차시 | 2024.08.10 |  누적합, 수학  | <a href="https://www.acmicpc.net/problem/9527">1의 개수 세기</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/228
 | 70차시 | 2024.08.16 |  스택  | <a href="https://www.acmicpc.net/problem/22866">탑 보기</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/232
+| 71차시 | 2024.08.20 |  다익스트라  | <a href="https://www.acmicpc.net/problem/24042">다익스트라</a> | https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/235
 ---

--- a/tgyuuAn/다익스트라/횡단보도.py
+++ b/tgyuuAn/다익스트라/횡단보도.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+from heapq import *
+import sys
+
+def input(): return sys.stdin.readline().rstrip()
+MAX = 100_000 * 700_000 + 1
+N, M = map(int, input().split())
+
+graph = defaultdict(lambda : defaultdict(list))
+
+for idx in range(1,M+1):
+    start, destination = map(int, input().split())
+    graph[start][destination].append(idx)
+    graph[destination][start].append(idx)
+    
+costs = [MAX for _ in range(N+1)]
+visited = set()
+heap = [(0, 1)]
+while heap:
+    now_cost, now_idx = heappop(heap)
+    
+    if now_idx in visited: continue
+    visited.add(now_idx)
+    
+    if costs[now_idx] <= now_cost: continue
+    costs[now_idx] = now_cost
+    
+    if now_idx == N: break
+
+    for neighbor in graph[now_idx]:
+        if neighbor in visited: continue
+        
+        for neighbor_idx in graph[now_idx][neighbor]:
+    
+            real_idx = now_cost % M
+            if real_idx < neighbor_idx:
+                heappush(heap, (neighbor_idx - real_idx + now_cost, neighbor))
+            else:
+                heappush(heap, (now_cost + M - real_idx + neighbor_idx, neighbor))
+print(costs[-1])


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[횡단보도](https://www.acmicpc.net/problem/24042)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
**1시간 20분**

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

![image](https://github.com/user-attachments/assets/2c5f5d70-26d9-4fec-9fe0-12cdd3c2555c)

완탐으로 풀었을 때 시간 복잡도 : $100,000 * 700,000 = 7백억$ 당연히 시간 초과!!!!!!

<br><br><br>

`노드 <= 10만`, `간선 <= 70만`인 문제를 풀기위해서는 최대 $N log (N)$의 시간복잡도 이내로 풀어야 함. _(1억번 연산을 넘으면 안되기 때문)_

이 때 문제에서 힌트로 주어진 것이 바로 메모리 제한이 1024MB로 매우 널널하다는 것

<img width="306" alt="image" src="https://github.com/user-attachments/assets/c041fef5-8ac8-443c-8df7-32f82af78ed7">

<br><br><br>

그럼 DP로 접근해야되나 ...? 라고 곰곰히 생각해봤는데 도저히 DP로 풀 수 없다.

그래서 $N*log(N)$ 이내의 알고리즘이 뭐가 있을까 쭉 나열해봤다.

<br><br><Br>

힙, 정렬 + 이분탐색, 정렬, 다익스트라,  ,,,,,,,,,, **다익스트라** ?!

<br><br><br>

다익스트라의 시간복잡도는 $간선의 수 * log(간선의 수)$

= 70만 * log(70만) 

= 70만 * ( log(1024) + log(700) )

= 70만 * (10 + 약 9)

= 1310만

-> 완죤 가능...!

<br><br><br><br><br><br>

그래서 코드를 바로 와다다 썼고,

```python
from collections import defaultdict
from heapq import *
import sys

def input(): return sys.stdin.readline().rstrip()

N, M = map(int, input().split())

graph = defaultdict(lambda : defaultdict(int))

for idx in range(M):
    start, destination = map(int, input().split())
    graph[start][destination] = min(graph[start][destination], idx) if graph[start][destination] != 0 else idx
    graph[destination][start] = min(graph[destination][start], idx) if graph[destination][start] != 0 else idx

costs = [int(1e9) for _ in range(N+1)]
costs[1] = 0
visited = set()
heap = [(0, 1)]
while heap:
    now_cost, now_idx = heappop(heap)
    
    if now_idx in visited: continue
    visited.add(now_idx)
    
    costs[now_idx] = now_cost
    if now_idx == N: break

    for neighbor in graph[now_idx]:
        if graph[now_idx][neighbor] == 0: continue
        if neighbor in visited: continue

        if now_cost + graph[now_idx][neighbor] < costs[neighbor]:
            heappush(heap, (now_cost+graph[now_idx][neighbor]+1, neighbor))

print(costs[-1])
```

호기롭게 틀려버렸다..

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/51f1ddf0-41df-456e-afbd-eff38d05e3ef">

<br><br><br><br><br><br>

왜 틀렸을까 곰곰히 생각해보다가 아래와 같은 반례를 생각해냈다.

```
5 4
4 5
3 4
2 3
1 2
```

첫 번째 주기에서는 3 -> 4초에 2번노드로 이동되었고,

두 번째 주기에서 6 -> 7 초에 3번 노드로 이동되었고,

세 번째 주기에서는 9 -> 10 초에 4번 노드로 이동되었고,

네 번째 주기인 12 -> 13 초가 되어서야 5번 노드로 도착할 수 있다.

즉, 한 주기가 지날 때 마다 **총 주기인 M을 고려해서 시간을 더해줘야 된다는 것**.

<br><br><br><br><br><br>

또 여기서 한 번 더 생각해줘야 하는 것이,

아래와 같은 예시가 있을 때,

```
5 5
4 5
3 4
2 3
1 2       // 3-> 4초에 2번 노드로 이동
2 3      // 4 -> 5초에 바로 3번 노드로 이동 가능
```

`2 -> 3` 간선이 여러개 있을 때, 2번노드로 갈 수 있는 간선이 해당 간선 이전에 등장할 경우 똑같은 주기에서 이동할 수 있다는 것이다.

이 것만 처리해주면 야무지게 점수를 챙길 수 있다!

**이제 이 것을 어떻게 처리해줄 것이냐가 관건!!!**


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
